### PR TITLE
Add `--no-gitignore` Flag

### DIFF
--- a/docs/src/commands/build.md
+++ b/docs/src/commands/build.md
@@ -7,7 +7,8 @@ wasm binary, a JS wrapper file, your `README`, and a `package.json` file.
 
 The `pkg` directory is automatically `.gitignore`d by default, since it contains
 build artifacts which are not intended to be checked into version
-control.<sup>[0](#footnote-0)</sup>
+control.<sup>[0](#footnote-0)</sup> You can disable this with the
+[`--no-gitignore` flag](#skip-gitignore).
 
 ## Path
 
@@ -138,6 +139,20 @@ example, to build the previous example using cargo's offline feature:
 wasm-pack build examples/js-hello-world --mode no-install -- --offline
 ```
 
+## Skip .gitignore
+
+By default, `wasm-pack` creates a `.gitignore` file in the output directory
+containing `*`, which prevents the build artifacts from being checked into
+version control. If you want to commit the `pkg` directory to your repository
+(e.g. for GitHub Pages, Deno packages, or monorepo setups), you can use the
+`--no-gitignore` flag to skip generating the `.gitignore` file:
+
+```
+wasm-pack build --no-gitignore
+```
+
+This is also available with `--target web` and other targets.
+
 ## Panic strategy
 
 By default, Rust panics in WebAssembly compile with `panic=abort`, which aborts
@@ -243,4 +258,5 @@ it sees a `wasm64-*` triple:
 
 <sup id="footnote-0">0</sup> If you need to include additional assets in the pkg
 directory and your NPM package, we intend to have a solution for your use case
-soon. [↩](#wasm-pack-build)
+soon. You can use `--no-gitignore` to omit the `.gitignore` file in the
+meantime. [↩](#wasm-pack-build)

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -29,6 +29,7 @@ pub struct Build {
     pub crate_data: manifest::CrateData,
     pub scope: Option<String>,
     pub disable_dts: bool,
+    pub no_gitignore: bool,
     pub weak_refs: bool,
     pub reference_types: bool,
     pub target: Target,
@@ -136,6 +137,10 @@ pub struct BuildOptions {
     /// this flag will disable generating this TypeScript file.
     pub disable_dts: bool,
 
+    #[clap(long = "no-gitignore")]
+    /// Skip generating `.gitignore` file in the output directory.
+    pub no_gitignore: bool,
+
     #[clap(long = "weak-refs")]
     /// Enable usage of the JS weak references proposal.
     pub weak_refs: bool,
@@ -205,6 +210,7 @@ impl Default for BuildOptions {
             scope: None,
             mode: InstallMode::default(),
             disable_dts: false,
+            no_gitignore: false,
             weak_refs: false,
             reference_types: false,
             target: Target::default(),
@@ -283,6 +289,7 @@ impl Build {
             crate_data,
             scope: build_opts.scope,
             disable_dts: build_opts.disable_dts,
+            no_gitignore: build_opts.no_gitignore,
             weak_refs: build_opts.weak_refs,
             reference_types: build_opts.reference_types,
             target: build_opts.target,
@@ -432,7 +439,7 @@ impl Build {
 
     fn step_create_dir(&mut self) -> Result<()> {
         info!("Creating a pkg directory...");
-        create_pkg_dir(&self.out_dir)?;
+        create_pkg_dir(&self.out_dir, self.no_gitignore)?;
         info!("Created a pkg directory at {:#?}.", &self.crate_path);
         Ok(())
     }

--- a/src/command/utils.rs
+++ b/src/command/utils.rs
@@ -36,10 +36,12 @@ fn find_manifest_from_cwd() -> Result<PathBuf> {
 }
 
 /// Construct our `pkg` directory in the crate.
-pub fn create_pkg_dir(out_dir: &Path) -> Result<()> {
+pub fn create_pkg_dir(out_dir: &Path, no_gitignore: bool) -> Result<()> {
     let _ = fs::remove_file(out_dir.join("package.json")); // Clean up package.json from previous runs
     fs::create_dir_all(&out_dir)?;
-    fs::write(out_dir.join(".gitignore"), "*")?;
+    if !no_gitignore {
+        fs::write(out_dir.join(".gitignore"), "*")?;
+    }
     Ok(())
 }
 

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -260,7 +260,9 @@ pub fn cargo_install(
         .arg("--force")
         .arg(crate_name)
         .arg("--root")
-        .arg(&tmp);
+        .arg(&tmp)
+        .arg("--target-dir")
+        .arg(tmp.join("build"));
 
     if version != "latest" {
         cmd.arg("--version").arg(version);

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -243,7 +243,7 @@ pub fn cargo_install(
 
     // Run `cargo install` to a temporary location to handle ctrl-c gracefully
     // and ensure we don't accidentally use stale files in the future
-    let tmp = cache.join(format!(".{}", dirname).as_ref());
+    let tmp = cache.join(format!(".{}-pid{}", dirname, std::process::id(),).as_ref());
     drop(fs::remove_dir_all(&tmp));
     debug!("cargo installing {} to tempdir: {}", tool, tmp.display(),);
 

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -77,7 +77,7 @@ fn it_creates_a_package_json_default_path() {
     let fixture = fixture::js_hello_world();
     let out_dir = fixture.path.join("pkg");
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
-    wasm_pack::command::utils::create_pkg_dir(&out_dir).unwrap();
+    wasm_pack::command::utils::create_pkg_dir(&out_dir, false).unwrap();
     assert!(crate_data
         .write_package_json(&out_dir, &None, false, Target::Bundler)
         .is_ok());
@@ -117,7 +117,7 @@ fn it_creates_a_package_json_provided_path() {
     let fixture = fixture::js_hello_world();
     let out_dir = fixture.path.join("pkg");
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
-    wasm_pack::command::utils::create_pkg_dir(&out_dir).unwrap();
+    wasm_pack::command::utils::create_pkg_dir(&out_dir, false).unwrap();
     assert!(crate_data
         .write_package_json(&out_dir, &None, false, Target::Bundler)
         .is_ok());
@@ -147,7 +147,7 @@ fn it_creates_a_package_json_provided_path_with_scope() {
     let fixture = fixture::js_hello_world();
     let out_dir = fixture.path.join("pkg");
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
-    wasm_pack::command::utils::create_pkg_dir(&out_dir).unwrap();
+    wasm_pack::command::utils::create_pkg_dir(&out_dir, false).unwrap();
     assert!(crate_data
         .write_package_json(&out_dir, &Some("test".to_string()), false, Target::Bundler,)
         .is_ok());
@@ -177,7 +177,7 @@ fn it_creates_a_pkg_json_with_correct_files_on_node() {
     let fixture = fixture::js_hello_world();
     let out_dir = fixture.path.join("pkg");
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
-    wasm_pack::command::utils::create_pkg_dir(&out_dir).unwrap();
+    wasm_pack::command::utils::create_pkg_dir(&out_dir, false).unwrap();
     assert!(crate_data
         .write_package_json(&out_dir, &None, false, Target::Nodejs)
         .is_ok());
@@ -211,7 +211,7 @@ fn it_creates_a_pkg_json_with_correct_files_on_nomodules() {
     let fixture = fixture::js_hello_world();
     let out_dir = fixture.path.join("pkg");
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
-    wasm_pack::command::utils::create_pkg_dir(&out_dir).unwrap();
+    wasm_pack::command::utils::create_pkg_dir(&out_dir, false).unwrap();
     assert!(crate_data
         .write_package_json(&out_dir, &None, false, Target::NoModules)
         .is_ok());
@@ -245,7 +245,7 @@ fn it_creates_a_package_json_with_correct_files_when_out_name_is_provided() {
     let fixture = fixture::js_hello_world();
     let out_dir = fixture.path.join("pkg");
     let crate_data = manifest::CrateData::new(&fixture.path, Some("index".to_owned())).unwrap();
-    wasm_pack::command::utils::create_pkg_dir(&out_dir).unwrap();
+    wasm_pack::command::utils::create_pkg_dir(&out_dir, false).unwrap();
     assert!(crate_data
         .write_package_json(&out_dir, &None, false, Target::Bundler)
         .is_ok());
@@ -278,7 +278,7 @@ fn it_creates_a_pkg_json_in_out_dir() {
     let fixture = fixture::js_hello_world();
     let out_dir = fixture.path.join("./custom/out");
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
-    wasm_pack::command::utils::create_pkg_dir(&out_dir).unwrap();
+    wasm_pack::command::utils::create_pkg_dir(&out_dir, false).unwrap();
     assert!(crate_data
         .write_package_json(&out_dir, &None, false, Target::Bundler)
         .is_ok());
@@ -293,7 +293,7 @@ fn it_creates_a_package_json_with_correct_keys_when_types_are_skipped() {
     let fixture = fixture::js_hello_world();
     let out_dir = fixture.path.join("pkg");
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
-    wasm_pack::command::utils::create_pkg_dir(&out_dir).unwrap();
+    wasm_pack::command::utils::create_pkg_dir(&out_dir, false).unwrap();
     assert!(crate_data
         .write_package_json(&out_dir, &None, true, Target::Bundler)
         .is_ok());
@@ -341,7 +341,7 @@ fn it_creates_a_package_json_with_npm_dependencies_provided_by_wasm_bindgen() {
     let fixture = fixture::js_hello_world();
     let out_dir = fixture.path.join("pkg");
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
-    wasm_pack::command::utils::create_pkg_dir(&out_dir).unwrap();
+    wasm_pack::command::utils::create_pkg_dir(&out_dir, false).unwrap();
     // Write a `package.json` in the out_dir, as wasm-bindgen does:
     utils::manifest::create_wbg_package_json(
         &out_dir,
@@ -421,7 +421,7 @@ fn it_sets_homepage_field_if_available_in_cargo_toml() {
     let out_dir = fixture.path.join("pkg");
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
 
-    wasm_pack::command::utils::create_pkg_dir(&out_dir).unwrap();
+    wasm_pack::command::utils::create_pkg_dir(&out_dir, false).unwrap();
     crate_data
         .write_package_json(&out_dir, &None, true, Target::Bundler)
         .unwrap();
@@ -437,7 +437,7 @@ fn it_sets_homepage_field_if_available_in_cargo_toml() {
     let out_dir = fixture.path.join("pkg");
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
 
-    wasm_pack::command::utils::create_pkg_dir(&out_dir).unwrap();
+    wasm_pack::command::utils::create_pkg_dir(&out_dir, false).unwrap();
     crate_data
         .write_package_json(&out_dir, &None, true, Target::Bundler)
         .unwrap();
@@ -476,7 +476,7 @@ fn it_sets_keywords_field_if_available_in_cargo_toml() {
     let out_dir = fixture.path.join("pkg");
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
 
-    wasm_pack::command::utils::create_pkg_dir(&out_dir).unwrap();
+    wasm_pack::command::utils::create_pkg_dir(&out_dir, false).unwrap();
     crate_data
         .write_package_json(&out_dir, &None, true, Target::Bundler)
         .unwrap();
@@ -494,7 +494,7 @@ fn it_sets_keywords_field_if_available_in_cargo_toml() {
     let out_dir = fixture.path.join("pkg");
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
 
-    wasm_pack::command::utils::create_pkg_dir(&out_dir).unwrap();
+    wasm_pack::command::utils::create_pkg_dir(&out_dir, false).unwrap();
     crate_data
         .write_package_json(&out_dir, &None, true, Target::Bundler)
         .unwrap();
@@ -592,7 +592,7 @@ fn it_lists_license_files_in_files_field_of_package_json() {
 
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
 
-    wasm_pack::command::utils::create_pkg_dir(&out_dir).unwrap();
+    wasm_pack::command::utils::create_pkg_dir(&out_dir, false).unwrap();
     license::copy_from_crate(&crate_data, &fixture.path, &out_dir).unwrap();
     crate_data
         .write_package_json(&out_dir, &None, false, Target::Bundler)


### PR DESCRIPTION
This closes or supersedes these issues and PRs:
Closes: #728, #909, #984, #999
Supersedes: #985, #1131, #1408

This PR adds a `--no-gitignore` flag (named that rather than `--skip-gitignore` for consistency) to help fix the above issues!

After some CI failures, 2 changes were made to make them more robust when running:
- Made tmp dir unique with PID suffix: Changed from .".{dirname}" to .".{dirname}-pid{PID}"
- Added --target-dir: Pass --target-dir tmp/build to cargo install



- [X] You have the latest version of `rustfmt` installed
- [X] You ran `cargo fmt` on the code base before submitting
- [X] You reference which issue is being closed in the PR text.