### PR TITLE
fix: pass --enable-exception-handling to wasm-opt for --panic-unwind builds

### DIFF
--- a/docs/src/commands/build.md
+++ b/docs/src/commands/build.md
@@ -170,6 +170,8 @@ This flag:
 - Adds `-Z build-std=std,panic_unwind` to rebuild `std` with unwinding
   support.
 - Sets `RUSTFLAGS=-Cpanic=unwind` (preserving any user-provided `RUSTFLAGS`).
+- Passes `--enable-exception-handling` to `wasm-opt` so the optimiser accepts
+  the exception-handling instructions unwinding compiles to.
 
 The first time you use `--panic-unwind`, `wasm-pack` will install any missing
 prerequisites via `rustup`:

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -521,6 +521,9 @@ impl Build {
         if build::is_tier3_wasm(&self.target_triple) {
             args.push("--enable-memory64".into());
         }
+        if self.panic_unwind {
+            args.push("--enable-exception-handling".into());
+        }
         info!("executing wasm-opt with {:?}", args);
         wasm_opt::run(
             &self.cache,


### PR DESCRIPTION
Follow-up to #1572. `--panic-unwind` builds compile unwinding to the Wasm exception-handling proposal, but the wasm-opt step only worked implicitly via Binaryen's feature detection of the LLVM `target_features` custom section. If that section is stripped, or an older `wasm-opt` on `PATH` is picked up ahead of the downloaded Binaryen, the optimisation step fails feature validation.

This explicitly passes `--enable-exception-handling` to `wasm-opt` when `--panic-unwind` is set, matching the existing handling for `--reference-types` and memory64, and documents it in the build command guide.